### PR TITLE
Feat/styling timeslots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+**/.DS_Store

--- a/src/DayHeader.css
+++ b/src/DayHeader.css
@@ -23,7 +23,8 @@
   flex-grow: 1;
   flex-shrink: 1;
   padding: 3px;
-  border-radius: 3px;
-  background-color: #666;
-  color: #fff;
+  border-radius: 2px;
+  background-color: #C5CCD0;
+  color: #3D464D;
+  margin: 1px;
 }

--- a/src/DayHeader.jsx
+++ b/src/DayHeader.jsx
@@ -58,10 +58,6 @@ export default class DayHeader extends Component {
             <div
               key={i + event.title}
               className={styles.event}
-              style={{
-                color: event.foregroundColor,
-                backgroundColor: event.backgroundColor,
-              }}
               title={event.title}
             >
               {event.title}

--- a/src/TimeSlot.css
+++ b/src/TimeSlot.css
@@ -52,7 +52,6 @@
 
 :local(.title) {
   padding: 5px;
-  text-align: center;
   font-size: 10px;
   font-weight: 100;
   overflow: hidden;

--- a/src/TimeSlot.css
+++ b/src/TimeSlot.css
@@ -1,6 +1,6 @@
 :local(.component) {
-  background-color: #4477BD;
-  border-radius: 3px;
+  background-color: #0070E0;
+  border-radius: 1px;
   position: absolute;
   width: 100%;
   color: #fff;
@@ -34,9 +34,9 @@
 }
 
 :local(.frozen) {
-  background-color: #fff;
-  color: #333;
-  border: 1px solid #ccc;
+  background-color: #C5CCD0;
+  color: #3D464D;
+  border: 1px solid #7B8994;
   opacity: 1;
   cursor: default;
 }

--- a/src/TimeSlot.jsx
+++ b/src/TimeSlot.jsx
@@ -100,8 +100,6 @@ export default class TimeSlot extends PureComponent {
     const style = {
       top,
       height: bottom - top,
-      backgroundColor,
-      color: foregroundColor,
     };
 
     if (typeof width !== 'undefined' && typeof offset !== 'undefined') {

--- a/src/Week.jsx
+++ b/src/Week.jsx
@@ -97,6 +97,7 @@ export default class Week extends PureComponent {
           className={styles.header}
           style={{
             paddingLeft: RULER_WIDTH_IN_PIXELS,
+            paddingRight: '15px',
           }}
         >
           {week.days.map((day, i) => (


### PR DESCRIPTION
- Greying out all (frozen) events for a less cluttered view and giving a selections a starker blue
- Minor details as less border-radius and left-align on event titles
- I left the backgroundColor and foregroundColor props as is, perhaps they will come into use when displaying event description/location (with calendar-colored title)?
- Added 15px padding-right on DayHeader wrapping div, to align the haeder columns with the grid's columns.