### PR TITLE
Fix/surrounding styling

### DIFF
--- a/src/AvailableTimes.css
+++ b/src/AvailableTimes.css
@@ -32,7 +32,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px;
+  padding: 10px 20px 25px;
   font-size: 18px;
 }
 

--- a/src/Ruler.css
+++ b/src/Ruler.css
@@ -1,5 +1,7 @@
 :local(.component) {
   flex-shrink: 0;
+  position: relative;
+  background-color: #fff;
 }
 :local(.hour) {
   text-align: right;


### PR DESCRIPTION
- Set white background in left gutter to have a cleaner look.
-  Increase padding (L/R/B) to toolbar to visually separate more from calendar grid.