### PR TITLE
Fix scrolltop issue

### DIFF
--- a/src/Day.jsx
+++ b/src/Day.jsx
@@ -27,7 +27,9 @@ export default class Day extends PureComponent {
     this.handleSizeChangeStart = this.handleItemModification.bind(this, 'end');
     this.handleMoveStart = this.handleItemModification.bind(this, 'both');
     this.handleDelete = this.handleDelete.bind(this);
-    this.handleMouseTargetRef = element => (this.mouseTargetRef = element);
+    this.handleMouseTargetRef = (element) => {
+      this.mouseTargetRef = element;
+    };
   }
 
   findSelectionAt(date) {
@@ -46,7 +48,8 @@ export default class Day extends PureComponent {
 
   relativeY(pageY, rounding = ROUND_TO_NEAREST_MINS) {
     const { top } = this.mouseTargetRef.getBoundingClientRect();
-    let realY = pageY - top - document.body.scrollTop;
+    let realY = pageY - top - (window.pageYOffset ||
+      document.documentElement.scrollTop || document.body.scrollTop || 0);
     realY += this.props.hourLimits.top; // offset top blocker
     const snapTo = (rounding / 60) * HOUR_IN_PIXELS;
     return Math.floor(realY / snapTo) * snapTo;


### PR DESCRIPTION
Hey, 

Firstly great component, really easy to use, thanks!

I ran into an issue when you use react-available-times after having scrolled the page. A simple way of replicating the issue is adding a div with 100vh as the first child in your test.jsx file. It doesn't offset the vertical scroll correctly.

The basic problem is in regards to document.body.scrollTop, I'm not 100% on the issue but it doesn't seem to work anymore!? See this issue on [Chromium bug site](https://bugs.chromium.org/p/chromium/issues/detail?id=766938). It's a simple fix, I used a pattern that is seems to be OK for all browsers ([from here](https://stackoverflow.com/a/20478983/2368141)). But in general I think just document.documentElement.scrollTop would have been fine.

[Someone actually beat me to it](https://github.com/trotzig/react-available-times/pull/9), but they closed their pull request :(