### PR TITLE
fix days of week in non-en locale

### DIFF
--- a/src/Week.jsx
+++ b/src/Week.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import momentTimezone from 'moment-timezone';
+import moment from 'moment';
 
 import { HOUR_IN_PIXELS, RULER_WIDTH_IN_PIXELS, MINUTE_IN_PIXELS } from './Constants';
 import { validateDays } from './Validators';
@@ -110,11 +111,12 @@ export default class Week extends PureComponent {
   // generate the props required for Day to block specific hours.
   generateHourLimits() {
     const { availableHourRange } = this.props;
-    return { top: availableHourRange.start * HOUR_IN_PIXELS, // top blocker
+    return {
+      top: availableHourRange.start * HOUR_IN_PIXELS, // top blocker
       bottom: availableHourRange.end * HOUR_IN_PIXELS,
       bottomHeight: (24 - availableHourRange.end) * HOUR_IN_PIXELS, // bottom height
       difference: ((availableHourRange.end - availableHourRange.start) * HOUR_IN_PIXELS)
-      + (MINUTE_IN_PIXELS * 14),
+        + (MINUTE_IN_PIXELS * 14),
     };
   }
 
@@ -149,7 +151,8 @@ export default class Week extends PureComponent {
 
     const filteredDays = week.days.map((day) => {
       const updatedDay = day;
-      updatedDay.available = availableDays.includes(day.name.toLowerCase());
+      const dayNameInEnglish = moment(day.date).locale('en').format('dddd').toLowerCase();
+      updatedDay.available = availableDays.includes(dayNameInEnglish);
       return updatedDay;
     });
     return (


### PR DESCRIPTION
Hey again!

Ran into an issue where the component would fail when the moment.locale() was specified in non-English. Essentially this is caused because there is a DAYS_IN_WEEK const in English, but if you change the locale, moment will translate the week names into the user's language, so the check days are available function will fail.

You can test this breaking by importing moment into the **test.jsx** file and then changing the locale `
```javascript 
import moment from 'moment';
moment.locale('es-es')
```

Also, I noticed 2 tests are failing. I swear they failed before I touched anything! I don't have the time to fix them right now, sorry.